### PR TITLE
fix: use strict semver version for autogenerated tags

### DIFF
--- a/plugin/tags.go
+++ b/plugin/tags.go
@@ -30,17 +30,6 @@ func DefaultTagSuffix(ref, suffix string) ([]string, error) {
 	return tags, nil
 }
 
-func splitOff(input, delim string) string {
-	const splits = 2
-	parts := strings.SplitN(input, delim, splits)
-
-	if len(parts) == splits {
-		return parts[0]
-	}
-
-	return input
-}
-
 // DefaultTags returns a set of default suggested tags based on
 // the commit ref.
 func DefaultTags(ref string) ([]string, error) {
@@ -61,38 +50,17 @@ func DefaultTags(ref string) ([]string, error) {
 		}, nil
 	}
 
-	rawVersion = stripTagPrefix(ref)
-	rawVersion = splitOff(splitOff(rawVersion, "+"), "-")
-	//nolint:gomnd
-	dotParts := strings.SplitN(rawVersion, ".", 3)
-
 	if version.Major == 0 {
 		return []string{
-			fmt.Sprintf("%0*d.%0*d", len(dotParts[0]), version.Major, len(dotParts[1]), version.Minor),
-			fmt.Sprintf(
-				"%0*d.%0*d.%0*d",
-				len(dotParts[0]),
-				version.Major,
-				len(dotParts[1]),
-				version.Minor,
-				len(dotParts[2]),
-				version.Patch,
-			),
+			fmt.Sprintf("%v.%v", version.Major, version.Minor),
+			fmt.Sprintf("%v.%v.%v", version.Major, version.Minor, version.Patch),
 		}, nil
 	}
 
 	return []string{
-		fmt.Sprintf("%0*d", len(dotParts[0]), version.Major),
-		fmt.Sprintf("%0*d.%0*d", len(dotParts[0]), version.Major, len(dotParts[1]), version.Minor),
-		fmt.Sprintf(
-			"%0*d.%0*d.%0*d",
-			len(dotParts[0]),
-			version.Major,
-			len(dotParts[1]),
-			version.Minor,
-			len(dotParts[2]),
-			version.Patch,
-		),
+		fmt.Sprintf("%v", version.Major),
+		fmt.Sprintf("%v.%v", version.Major, version.Minor),
+		fmt.Sprintf("%v.%v.%v", version.Major, version.Minor, version.Patch),
 	}, nil
 }
 

--- a/plugin/tags_test.go
+++ b/plugin/tags_test.go
@@ -36,6 +36,7 @@ func TestDefaultTags(t *testing.T) {
 		{"refs/tags/v1.0.0+1", []string{"1", "1.0", "1.0.0"}},
 		{"refs/tags/v1.0.0-alpha.1", []string{"1.0.0-alpha.1"}},
 		{"refs/tags/v1.0.0-alpha", []string{"1.0.0-alpha"}},
+		{"refs/tags/1.01.0", []string{"1", "1.1", "1.1.0"}},
 	}
 
 	for _, test := range tests {
@@ -117,8 +118,8 @@ func TestDefaultTagSuffix(t *testing.T) {
 			Suffix: "nanoserver",
 			After: []string{
 				"18-nanoserver",
-				"18.06-nanoserver",
-				"18.06.0-nanoserver",
+				"18.6-nanoserver",
+				"18.6.0-nanoserver",
 			},
 		},
 	}


### PR DESCRIPTION
BREAKING CHANGE: According to the [SemVer v2](https://semver.org/#spec-item-2) specs, version numbers MUST NOT contain leading zeroes. Autogenerated tags will now follow this spec and transform e.g. `v1.01.0` git tags to `1.1.0` container tags.